### PR TITLE
Fix segmentation fault on macOS ARM64 systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,9 @@ URL      = url
 VERSION  = version
 
 SRC = src/curl.f90 src/curl_easy.f90 src/curl_multi.f90 src/curl_urlapi.f90 \
-      src/curl_util.F90 src/curl_macro.c
+      src/curl_util.F90 src/curl_macro.c src/curl_getinfo.c
 MOD = curl.mod curl_easy.mod curl_multi.mod curl_urlapi.mod curl_util.mod
-OBJ = curl.o curl_easy.o curl_multi.o curl_urlapi.o curl_util.o curl_macro.o
+OBJ = curl.o curl_easy.o curl_multi.o curl_urlapi.o curl_util.o curl_macro.o curl_getinfo.o
 
 .PHONY: all clean examples
 
@@ -45,6 +45,7 @@ examples: $(DICT) $(DOWNLOAD) $(GETINFO) $(GOPHER) $(HTTP) $(IMAP) $(MQTT) \
 
 $(TARGET): $(SRC)
 	$(CC) $(CFLAGS) -c src/curl_macro.c
+	$(CC) $(CFLAGS) -c src/curl_getinfo.c
 	$(FC) $(FFLAGS) -c src/curl_util.F90
 	$(FC) $(FFLAGS) -c src/curl_easy.f90
 	$(FC) $(FFLAGS) -c src/curl_multi.f90

--- a/src/curl_easy.f90
+++ b/src/curl_easy.f90
@@ -815,6 +815,16 @@ module curl_easy
             type(c_ptr),         intent(in), value :: parameter
             integer(kind=c_int)                    :: curl_easy_getinfo_
         end function curl_easy_getinfo_
+        
+        ! C wrapper for curl_easy_getinfo_long (fixes macOS ARM64 issues)
+        function curl_easy_getinfo_long_wrapper(curl, option, parameter) bind(c, name='curl_easy_getinfo_long_wrapper')
+            import :: c_int, c_long, c_ptr
+            implicit none
+            type(c_ptr),         intent(in), value :: curl
+            integer(kind=c_int), intent(in), value :: option
+            integer(kind=c_long), intent(out)      :: parameter
+            integer(kind=c_int)                    :: curl_easy_getinfo_long_wrapper
+        end function curl_easy_getinfo_long_wrapper
 
         ! CURL *curl_easy_init(void)
         function curl_easy_init() bind(c, name='curl_easy_init')
@@ -1207,9 +1217,10 @@ contains
         integer(kind=i4), intent(out) :: parameter
         integer                       :: rc
 
-        integer(kind=c_long), target  :: i
+        integer(kind=c_long) :: i
 
-        rc = curl_easy_getinfo_(curl, option, c_loc(i))
+        ! Use C wrapper for better platform compatibility
+        rc = curl_easy_getinfo_long_wrapper(curl, option, i)
         parameter = int(i)
     end function curl_easy_getinfo_int
 
@@ -1220,9 +1231,10 @@ contains
         integer(kind=i8), intent(out) :: parameter
         integer                       :: rc
 
-        integer(kind=c_long), target  :: i
+        integer(kind=c_long) :: i
 
-        rc = curl_easy_getinfo_(curl, option, c_loc(i))
+        ! Use C wrapper for better platform compatibility
+        rc = curl_easy_getinfo_long_wrapper(curl, option, i)
         parameter = int(i, kind=i8)
     end function curl_easy_getinfo_long
 

--- a/src/curl_getinfo.c
+++ b/src/curl_getinfo.c
@@ -10,11 +10,9 @@
 
 /* Wrapper for getting long values (including HTTP response code) */
 int curl_easy_getinfo_long_wrapper(void *curl, int info, long *value) {
+    if (curl == NULL || value == NULL) {
+        return CURLE_BAD_FUNCTION_ARGUMENT;
+    }
     return (int)curl_easy_getinfo((CURL *)curl, (CURLINFO)info, value);
 }
 
-/* Wrapper for getting integer values */
-int curl_easy_getinfo_int_wrapper(void *curl, int info, long *value) {
-    /* curl_easy_getinfo always expects a long pointer for numeric values */
-    return (int)curl_easy_getinfo((CURL *)curl, (CURLINFO)info, value);
-}

--- a/src/curl_getinfo.c
+++ b/src/curl_getinfo.c
@@ -1,0 +1,20 @@
+/* curl_getinfo.c
+ *
+ * C wrapper for curl_easy_getinfo to fix platform-specific issues
+ * particularly on macOS ARM64 where direct Fortran binding causes problems
+ *
+ * Author:  Christopher Albert
+ * Licence: ISC
+ */
+#include <curl/curl.h>
+
+/* Wrapper for getting long values (including HTTP response code) */
+int curl_easy_getinfo_long_wrapper(void *curl, int info, long *value) {
+    return (int)curl_easy_getinfo((CURL *)curl, (CURLINFO)info, value);
+}
+
+/* Wrapper for getting integer values */
+int curl_easy_getinfo_int_wrapper(void *curl, int info, long *value) {
+    /* curl_easy_getinfo always expects a long pointer for numeric values */
+    return (int)curl_easy_getinfo((CURL *)curl, (CURLINFO)info, value);
+}

--- a/src/curl_macro.c
+++ b/src/curl_macro.c
@@ -15,26 +15,41 @@ int curl_version_now(void);
 /* Non-variadic wrappers to `curl_easy_setopt()`. */
 int curl_easy_setopt_c_char(CURL *curl, CURLoption option, char *value)
 {
+    if (curl == NULL) {
+        return CURLE_BAD_FUNCTION_ARGUMENT;
+    }
     return curl_easy_setopt(curl, option, value);
 }
 
 int curl_easy_setopt_c_funptr(CURL *curl, CURLoption option, void *value)
 {
+    if (curl == NULL) {
+        return CURLE_BAD_FUNCTION_ARGUMENT;
+    }
     return curl_easy_setopt(curl, option, value);
 }
 
 int curl_easy_setopt_c_int(CURL *curl, CURLoption option, int value)
 {
+    if (curl == NULL) {
+        return CURLE_BAD_FUNCTION_ARGUMENT;
+    }
     return curl_easy_setopt(curl, option, value);
 }
 
 int curl_easy_setopt_c_long(CURL *curl, CURLoption option, long value)
 {
+    if (curl == NULL) {
+        return CURLE_BAD_FUNCTION_ARGUMENT;
+    }
     return curl_easy_setopt(curl, option, value);
 }
 
 int curl_easy_setopt_c_ptr(CURL *curl, CURLoption option, void *value)
 {
+    if (curl == NULL) {
+        return CURLE_BAD_FUNCTION_ARGUMENT;
+    }
     return curl_easy_setopt(curl, option, value);
 }
 

--- a/src/curl_util.F90
+++ b/src/curl_util.F90
@@ -10,7 +10,7 @@ module curl_util
     implicit none
     private
 
-#if defined (__flang__) || (defined (__GFORTRAN__) && __GNUC__ >= 15 && __GNUC_MINOR__ >= 1)
+#if defined (__flang__) || (defined (__GFORTRAN__) && __GNUC__ > 15) || (defined (__GFORTRAN__) && __GNUC__ == 15 && __GNUC_MINOR__ >= 2)
 
     public :: c_unsigned
 


### PR DESCRIPTION
### **User description**
## Summary
This PR fixes a critical segmentation fault that occurs when using `curl_easy_getinfo` with `CURLINFO_RESPONSE_CODE` on macOS ARM64 systems.

## Problem
The fortran-curl binding for `curl_easy_getinfo` causes segmentation faults on macOS ARM64 due to incorrect pointer handling when passing values between Fortran and C. The issue manifests when trying to retrieve HTTP response codes, resulting in either crashes or garbage values.

## Solution
Implemented a minimal C wrapper that properly handles the curl API calls:
- Added `src/curl_getinfo.c` with wrapper functions for `curl_easy_getinfo`
- Updated `curl_easy_getinfo_int` and `curl_easy_getinfo_long` to use the C wrapper
- This ensures proper alignment and type handling across the Fortran-C interface boundary

## Changes
- **src/curl_getinfo.c**: New C wrapper for curl_easy_getinfo functions
- **src/curl_easy.f90**: Updated to use C wrapper instead of direct binding
- **Makefile**: Added compilation of the new C wrapper
- **src/curl_util.F90**: Fixed preprocessor check for GCC 15.1.0 compatibility

## Testing
Tested with the `getinfo` example on macOS ARM64:
- Before: Segmentation fault or garbage values when retrieving response code
- After: Correctly retrieves HTTP 200 status code

The fix maintains backward compatibility while resolving the platform-specific issue.

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix segmentation fault on macOS ARM64 systems

- Add C wrapper for `curl_easy_getinfo` functions

- Update Fortran bindings to use safer C wrapper

- Fix GCC 15.1.0 preprocessor compatibility check


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Fortran Code"] --> B["C Wrapper"] --> C["libcurl API"]
  B --> D["Safe Type Handling"]
  D --> E["Fixed Segfault"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>curl_easy.f90</strong><dd><code>Update Fortran bindings to use C wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/curl_easy.f90

<ul><li>Add C wrapper function binding for <code>curl_easy_getinfo_long_wrapper</code><br> <li> Update <code>curl_easy_getinfo_int</code> and <code>curl_easy_getinfo_long</code> to use C <br>wrapper<br> <li> Remove target attribute from local variables<br> <li> Replace direct <code>curl_easy_getinfo_</code> calls with wrapper calls</ul>


</details>


  </td>
  <td><a href="https://github.com/krystophny/fortran-curl/pull/1/files#diff-27b4bf0a9e56689b36cb51d6a4c87c379e099afdd9821ca32f11241301c84bf5">+16/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>curl_getinfo.c</strong><dd><code>Add C wrapper for curl_easy_getinfo functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/curl_getinfo.c

<ul><li>New C wrapper file for <code>curl_easy_getinfo</code> functions<br> <li> Implement <code>curl_easy_getinfo_long_wrapper</code> for safe long value retrieval<br> <li> Implement <code>curl_easy_getinfo_int_wrapper</code> for integer values<br> <li> Proper type casting and pointer handling for Fortran-C interface</ul>


</details>


  </td>
  <td><a href="https://github.com/krystophny/fortran-curl/pull/1/files#diff-b5a89c49e7a611aa852cb1cf4c547bb1d77edd94e2ab756b8483c3c35e9f7051">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>curl_util.F90</strong><dd><code>Fix GCC 15.1.0 preprocessor compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/curl_util.F90

<ul><li>Fix preprocessor condition for GCC 15.1.0 compatibility<br> <li> Update version check logic to handle GCC 15.2+ correctly</ul>


</details>


  </td>
  <td><a href="https://github.com/krystophny/fortran-curl/pull/1/files#diff-fd3949d1f500e1a42fb615a27213f9bd4dfc44d1746ed366818737f4abff75a7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Include new C wrapper in build process</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

<ul><li>Add <code>src/curl_getinfo.c</code> to SRC variable<br> <li> Add <code>curl_getinfo.o</code> to OBJ variable<br> <li> Add compilation step for <code>curl_getinfo.c</code></ul>


</details>


  </td>
  <td><a href="https://github.com/krystophny/fortran-curl/pull/1/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

